### PR TITLE
Enviroment variable doesn't exist on ubuntu. Fixed bug #1.

### DIFF
--- a/src/main/java/net/vhati/modmanager/core/FTLUtilities.java
+++ b/src/main/java/net/vhati/modmanager/core/FTLUtilities.java
@@ -31,7 +31,7 @@ public class FTLUtilities {
 		String gogPath = "GOG.com/Faster Than Light/resources";
 		String humblePath = "FTL/resources";
 
-		String xdgDataHome = System.getenv("XDG_DATA_HOME");
+		String xdgDataHome = System.getenv("HOME");
 		if (xdgDataHome == null)
 			xdgDataHome = System.getProperty("user.home") +"/.local/share";
 


### PR DESCRIPTION
Turns out it is a bug in Ubuntu systems. XDG variables aren't automatically set according to launchpad. 

Also, the .steam folder is created at ~ and XDG_DATA_HOME refers to ~./local/share.

Therefore I've changed the XDG_DATA_HOME variable to HOME. That appears to work.

https://bugs.launchpad.net/ubuntu/+source/xdg-user-dirs/+bug/1122613
